### PR TITLE
Adds support for attaching to a TGW selected by its name

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,4 +40,10 @@ jobs:
 
       - name: "make test"
         run: |
-          make test ARGS="-var assumer_account_role_name=test"
+          make test ARGS="-var aws_account_id_hub=${TF_VAR_aws_account_id_hub} -var aws_account_id_satellite=[${TF_VAR_aws_account_id_satellite}]"
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_aws_account_id_hub: ${{ secrets.aws_account_id_hub }}
+          TF_VAR_aws_account_id_satellite: ${{ secrets.aws_account_id_satellite }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+*tfplan*

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ Check the `subnet_name_keyword_selector` variable if you want to change this.
 |------|-------------|------|---------|:-----:|
 | aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
 | aws\_login\_profile | Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles | `any` | n/a | yes |
-| ram\_resource\_association\_id | Identifier of the Resource Access Manager Resource Association | `string` | n/a | yes |
 | role\_to\_assume\_hub | IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB) | `string` | n/a | yes |
 | aws\_account\_id\_satellite | AWS account number containing the TGW satellite | `string` | `""` | no |
 | destination\_cidr\_block | CIDR to be routed | `string` | `""` | no |
+| ram\_resource\_association\_id | Identifier of the Resource Access Manager Resource Association | `string` | `""` | no |
 | role\_to\_assume\_satellite | IAM role name to assume in the AWS account containing the TGW satellite (eg. ASSUME-ROLE-SATELLITE) | `string` | `""` | no |
 | satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
 | subnet\_name\_keyword\_selector | Keyword matching the name of the subnet(s) for which the routing will be added (i.e. private) | `string` | `"private"` | no |
+| transit\_gateway\_hub\_name | Name of the Transit Gateway to attach to | `string` | `""` | no |
 | transit\_gateway\_id | Identifier of the Transit Gateway | `string` | `""` | no |
 | transit\_gateway\_route\_table\_id | Identifier of the Transit Gateway Route Table | `string` | `""` | no |
 | vpc\_name\_to\_attach | Name of the satellite VPC to be attached to the TGW | `string` | `""` | no |
@@ -75,14 +76,17 @@ Check the `subnet_name_keyword_selector` variable if you want to change this.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+## To do
+
+- Collect TGW ID directly rather than using a RAM data source
+  ([currently not supported][7])
+- Add support for VPN attachments
+- Add support for passing IDs of subnets while fetching routing table IDs
+
 [1]: https://en.wikipedia.org/wiki/Star_network
 [2]: https://github.com/Flaconi/terraform-aws-transit-gateway-hub
 [3]: https://github.com/Flaconi/terraform-aws-transit-gateway-hub/tree/master/examples
 [4]: https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#examples
 [5]: https://www.terraform.io/docs/configuration/modules.html#passing-providers-explicitly
 [6]: https://www.terraform.io/docs/providers/aws/index.html#authentication
-
-## To do
-
-- Add support for passing the IDs of the subnets as an input variable
-- Add support for VPN attachments
+[7]: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-transit-gateways.html#options

--- a/data.tf
+++ b/data.tf
@@ -22,3 +22,41 @@ data "aws_route_table" "this" {
 
   subnet_id = sort(data.aws_subnet_ids.this[0].ids)[count.index]
 }
+
+data "aws_ec2_transit_gateway" "this" {
+  provider = aws.hub
+  count    = local.create ? 1 : 0
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+
+  filter {
+    name   = "owner-id"
+    values = [var.aws_account_id_hub]
+  }
+
+  filter {
+    name   = "transit-gateway-id"
+    values = [data.aws_ram_resource_share.this[0].tags.transit-gateway-id]
+  }
+}
+
+data "aws_ec2_transit_gateway_route_table" "this" {
+  provider = aws.hub
+  count    = local.create ? 1 : 0
+
+  filter {
+    name   = "transit-gateway-id"
+    values = [data.aws_ec2_transit_gateway.this[0].id]
+  }
+}
+
+data "aws_ram_resource_share" "this" {
+  provider = aws.hub
+  count    = local.create ? 1 : 0
+
+  name           = var.transit_gateway_hub_name
+  resource_owner = "SELF"
+}

--- a/data.tf
+++ b/data.tf
@@ -25,7 +25,7 @@ data "aws_route_table" "this" {
 
 data "aws_ec2_transit_gateway" "this" {
   provider = aws.hub
-  count    = local.create ? 1 : 0
+  count    = local.create && var.transit_gateway_hub_name != "" ? 1 : 0
 
   filter {
     name   = "state"
@@ -45,7 +45,7 @@ data "aws_ec2_transit_gateway" "this" {
 
 data "aws_ec2_transit_gateway_route_table" "this" {
   provider = aws.hub
-  count    = local.create ? 1 : 0
+  count    = local.create && var.transit_gateway_hub_name != "" ? 1 : 0
 
   filter {
     name   = "transit-gateway-id"
@@ -55,7 +55,7 @@ data "aws_ec2_transit_gateway_route_table" "this" {
 
 data "aws_ram_resource_share" "this" {
   provider = aws.hub
-  count    = local.create ? 1 : 0
+  count    = local.create && var.transit_gateway_hub_name != "" ? 1 : 0
 
   name           = var.transit_gateway_hub_name
   resource_owner = "SELF"

--- a/examples/satellite/README.md
+++ b/examples/satellite/README.md
@@ -1,0 +1,27 @@
+# Standalone invocation of the Transit Gateway satellite module
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
+| aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list` | n/a | yes |
+| aws\_login\_profile | Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles | `any` | n/a | yes |
+| role\_to\_assume\_hub | IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB) | `string` | n/a | yes |
+| role\_to\_assume\_satellite | IAM role name to assume in the AWS account containing the TGW satellite (eg. ASSUME-ROLE-SATELLITE) | `string` | n/a | yes |
+| destination\_cidr\_block | CIDR to be routed | `string` | `""` | no |
+| satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
+| subnet\_name\_keyword\_selector | Keyword matching the name of the subnet(s) for which the routing will be added (i.e. private) | `string` | `"private"` | no |
+| transit\_gateway\_hub\_name | Name of the Transit Gateway to attach to | `string` | `""` | no |
+| vpc\_name\_to\_attach | Name of the satellite VPC to be attached to the TGW | `string` | `""` | no |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/satellite/README.md
+++ b/examples/satellite/README.md
@@ -18,6 +18,7 @@ No provider.
 | satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
 | subnet\_name\_keyword\_selector | Keyword matching the name of the subnet(s) for which the routing will be added (i.e. private) | `string` | `"private"` | no |
 | transit\_gateway\_hub\_name | Name of the Transit Gateway to attach to | `string` | `""` | no |
+| transit\_gateway\_id | Identifier of the Transit Gateway | `string` | `""` | no |
 | vpc\_name\_to\_attach | Name of the satellite VPC to be attached to the TGW | `string` | `""` | no |
 
 ## Outputs

--- a/examples/satellite/locals.tf
+++ b/examples/satellite/locals.tf
@@ -1,0 +1,6 @@
+# Workaround for this error when passing undeclared vars using CI/CD
+# https://github.com/hashicorp/terraform/issues/22004
+# TODO: refactor it after issue is resolved
+locals {
+  aws_account_id_satellite = var.aws_account_id_satellite[0]
+}

--- a/examples/satellite/main.tf
+++ b/examples/satellite/main.tf
@@ -1,0 +1,26 @@
+# The Transit Gateway (hub) has already been created in AWS, as a fixture for
+# this test case due to not being able to use 'depends_on' on Terraform modules
+module "tgw-satellite" {
+  source = "../../../terraform-aws-transit-gateway-satellite/"
+
+  providers = {
+    aws.satellite = aws.satellite
+    aws.hub       = aws.hub
+  }
+
+  aws_login_profile = var.aws_login_profile
+  satellite_create  = var.satellite_create
+
+  aws_account_id_hub       = var.aws_account_id_hub
+  aws_account_id_satellite = local.aws_account_id_satellite
+
+  role_to_assume_hub       = var.role_to_assume_hub
+  role_to_assume_satellite = var.role_to_assume_satellite
+
+  vpc_name_to_attach     = var.vpc_name_to_attach
+  destination_cidr_block = var.destination_cidr_block
+
+  subnet_name_keyword_selector = var.subnet_name_keyword_selector
+
+  transit_gateway_hub_name = var.transit_gateway_hub_name
+}

--- a/examples/satellite/main.tf
+++ b/examples/satellite/main.tf
@@ -1,7 +1,7 @@
 # The Transit Gateway (hub) has already been created in AWS, as a fixture for
 # this test case due to not being able to use 'depends_on' on Terraform modules
 module "tgw-satellite" {
-  source = "../../../terraform-aws-transit-gateway-satellite/"
+  source = "../../"
 
   providers = {
     aws.satellite = aws.satellite

--- a/examples/satellite/providers.tf
+++ b/examples/satellite/providers.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  alias   = "satellite"
+  region  = "eu-central-1"
+  profile = var.aws_login_profile
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.aws_account_id_satellite}:role/${var.role_to_assume_satellite}"
+    session_name = "tf-tgw-module-satellite"
+  }
+}
+
+provider "aws" {
+  alias   = "hub"
+  region  = "eu-central-1"
+  profile = var.aws_login_profile
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.aws_account_id_hub}:role/${var.role_to_assume_hub}"
+    session_name = "tf-tgw-module-satellite"
+  }
+}

--- a/examples/satellite/variables.auto.tfvars
+++ b/examples/satellite/variables.auto.tfvars
@@ -1,0 +1,12 @@
+satellite_create = true
+
+aws_login_profile = "login"
+
+role_to_assume_hub       = "ASSUME-ENG-CI"
+role_to_assume_satellite = "ASSUME-ENG-CI"
+
+vpc_name_to_attach     = "default"
+destination_cidr_block = "1.1.1.1/32"
+
+subnet_name_keyword_selector = "private"
+transit_gateway_hub_name     = "test-tgw-fixture"

--- a/examples/satellite/variables.tf
+++ b/examples/satellite/variables.tf
@@ -50,3 +50,9 @@ variable "transit_gateway_hub_name" {
   type        = string
   default     = ""
 }
+
+variable "transit_gateway_id" {
+  description = "Identifier of the Transit Gateway"
+  type        = string
+  default     = ""
+}

--- a/examples/satellite/variables.tf
+++ b/examples/satellite/variables.tf
@@ -1,0 +1,52 @@
+variable "satellite_create" {
+  description = "Boolean flag for toggling the handling of satellite resources"
+  default     = false
+  type        = bool
+}
+
+variable "aws_login_profile" {
+  description = "Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles"
+}
+
+variable "aws_account_id_hub" {
+  description = "AWS account number containing the TGW hub"
+  type        = string
+}
+
+variable "aws_account_id_satellite" {
+  description = "List of AWS account numbers representing the satellites of the TGW"
+  type        = list
+}
+
+variable "role_to_assume_hub" {
+  description = "IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB)"
+  type        = string
+}
+
+variable "role_to_assume_satellite" {
+  description = "IAM role name to assume in the AWS account containing the TGW satellite (eg. ASSUME-ROLE-SATELLITE)"
+  type        = string
+}
+
+variable "vpc_name_to_attach" {
+  description = "Name of the satellite VPC to be attached to the TGW"
+  type        = string
+  default     = ""
+}
+
+variable "destination_cidr_block" {
+  description = "CIDR to be routed"
+  default     = ""
+}
+
+variable "subnet_name_keyword_selector" {
+  description = "Keyword matching the name of the subnet(s) for which the routing will be added (i.e. private)"
+  type        = string
+  default     = "private"
+}
+
+variable "transit_gateway_hub_name" {
+  description = "Name of the Transit Gateway to attach to"
+  type        = string
+  default     = ""
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,7 @@
 locals {
   create = var.satellite_create
+
+  transit_gateway_id = var.transit_gateway_id == "" ? data.aws_ec2_transit_gateway.this[0].id : var.transit_gateway_id
+
+  transit_gateway_route_table_id = var.transit_gateway_route_table_id == "" ? data.aws_ec2_transit_gateway_route_table.this[0].id : var.transit_gateway_route_table_id
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,6 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
 
   # When we create the TGW and the association through RAM in one run, we need
   # this to escape the race condition.
-  #  depends_on = [var.ram_resource_association_id, data.aws_ram_resource_share.this.id]
   depends_on = [var.ram_resource_association_id]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,12 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   provider           = aws.satellite
   count              = local.create ? 1 : 0
   subnet_ids         = data.aws_subnet_ids.this[0].ids
-  transit_gateway_id = var.transit_gateway_id
+  transit_gateway_id = local.transit_gateway_id
   vpc_id             = data.aws_vpc.this[0].id
 
   # When we create the TGW and the association through RAM in one run, we need
   # this to escape the race condition.
+  #  depends_on = [var.ram_resource_association_id, data.aws_ram_resource_share.this.id]
   depends_on = [var.ram_resource_association_id]
 }
 
@@ -18,7 +19,7 @@ resource "aws_ec2_transit_gateway_route" "this" {
   count                          = local.create ? 1 : 0
   destination_cidr_block         = var.destination_cidr_block
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[0].id
-  transit_gateway_route_table_id = var.transit_gateway_route_table_id
+  transit_gateway_route_table_id = local.transit_gateway_route_table_id
   depends_on                     = [aws_ec2_transit_gateway_vpc_attachment.this]
 }
 
@@ -26,7 +27,7 @@ resource "aws_ec2_transit_gateway_route_table_association" "this" {
   provider                       = aws.hub
   count                          = local.create ? 1 : 0
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[0].id
-  transit_gateway_route_table_id = var.transit_gateway_route_table_id
+  transit_gateway_route_table_id = local.transit_gateway_route_table_id
   depends_on                     = [aws_ec2_transit_gateway_vpc_attachment.this]
 }
 
@@ -34,7 +35,7 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
   provider                       = aws.hub
   count                          = local.create ? 1 : 0
   transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[0].id
-  transit_gateway_route_table_id = var.transit_gateway_route_table_id
+  transit_gateway_route_table_id = local.transit_gateway_route_table_id
   depends_on                     = [aws_ec2_transit_gateway_vpc_attachment.this]
 }
 
@@ -43,7 +44,7 @@ resource "aws_route" "this" {
   count    = local.create ? length(data.aws_route_table.this[*].subnet_id) : 0
 
   destination_cidr_block = var.destination_cidr_block
-  transit_gateway_id     = var.transit_gateway_id
+  transit_gateway_id     = local.transit_gateway_id
   route_table_id         = sort(data.aws_route_table.this[*].route_table_id)[count.index]
 
   depends_on = [aws_ec2_transit_gateway_vpc_attachment.this]

--- a/variables.tf
+++ b/variables.tf
@@ -56,10 +56,17 @@ variable "transit_gateway_id" {
 variable "ram_resource_association_id" {
   description = "Identifier of the Resource Access Manager Resource Association"
   type        = string
+  default     = ""
 }
 
 variable "subnet_name_keyword_selector" {
   description = "Keyword matching the name of the subnet(s) for which the routing will be added (i.e. private)"
   type        = string
   default     = "private"
+}
+
+variable "transit_gateway_hub_name" {
+  description = "Name of the Transit Gateway to attach to"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
# Adds support for attaching to a TGW selected by its name

## Description
We want to be able to attach a VPC to a Transit Gateway by simply passing the name of the TGW.

## Testing Instructions
See the `examples/satellite` dir.

## How to roll out
N/A

## Notes
N/A

## Demo
N/A
