### PR TITLE
Fixes multiplexing of network routes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_route" "this" {
 
   destination_cidr_block = each.value[0].dest_cidr_block
   transit_gateway_id     = local.transit_gateway_id
-  route_table_id         = each.value[1].table_id
+  route_table_id         = each.value[0].table_id
 
   depends_on = [aws_ec2_transit_gateway_vpc_attachment.this]
 }


### PR DESCRIPTION
# Fixes multiplexing of network routes

## Description
This is a fix for the error shown below, when the input vars of the module are as follows (when the two lists are not equal in length):
```hcl
satellite_destination_cidr_blocks = ["1.1.1.1/16", "2.2.2.2/16"]
hub_destination_cidr_blocks       = ["3.3.3.3/16"]
```

```shell
Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/tgw-satellite/main.tf line 50, in resource "aws_route" "this":
  50:   route_table_id         = each.value[1].table_id
    |----------------
    | each.value is tuple with 1 element

The given key does not identify an element in this collection value.
```

## Testing Instructions
N/A

## How to roll out
N/A

## Notes
Test case will be added later.

## Demo
N/A
