### PR TITLE
Adds option to route the entire VPC through the TGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Check the `subnet_name_keyword_selector` variable if you want to change this.
 | hub\_destination\_cidr\_blocks | List of CIDRs to be routed for the hub | `list` | `[]` | no |
 | ram\_resource\_association\_id | Identifier of the Resource Access Manager Resource Association | `string` | `""` | no |
 | role\_to\_assume\_satellite | IAM role name to assume in the AWS account containing the TGW satellite (eg. ASSUME-ROLE-SATELLITE) | `string` | `""` | no |
+| route\_entire\_satellite\_vpc | Boolean flag for toggling the creation of network routes for all the subnets of the satellite VPC | `bool` | `false` | no |
 | satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
 | satellite\_destination\_cidr\_blocks | List of CIDRs to be routed for the satellite | `list` | `[]` | no |
 | subnet\_filters | List of maps selecting the subnet(s) for which the routing will be added | <pre>list(object({<br>    name   = string<br>    values = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "name": "tag:Name",<br>    "values": [<br>      "private"<br>    ]<br>  }<br>]<br></pre> | no |
@@ -82,7 +83,6 @@ Check the `subnet_name_keyword_selector` variable if you want to change this.
 - Collect TGW ID directly rather than using a RAM data source
   ([currently not supported][7])
 - Add support for VPN attachments
-- Add support for passing IDs of subnets while fetching routing table IDs
 
 [1]: https://en.wikipedia.org/wiki/Star_network
 [2]: https://github.com/Flaconi/terraform-aws-transit-gateway-hub

--- a/data.tf
+++ b/data.tf
@@ -28,6 +28,12 @@ data "aws_route_table" "this" {
   subnet_id = sort(data.aws_subnet_ids.this[0].ids)[count.index]
 }
 
+data "aws_route_tables" "all" {
+  provider = aws.satellite
+  count    = local.create && var.route_entire_satellite_vpc ? 1 : 0
+  vpc_id   = data.aws_vpc.this[0].id
+}
+
 data "aws_ec2_transit_gateway" "this" {
   provider = aws.hub
   count    = local.create && var.transit_gateway_hub_name != "" ? 1 : 0

--- a/examples/satellite/README.md
+++ b/examples/satellite/README.md
@@ -15,6 +15,7 @@ No provider.
 | role\_to\_assume\_hub | IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB) | `string` | n/a | yes |
 | role\_to\_assume\_satellite | IAM role name to assume in the AWS account containing the TGW satellite (eg. ASSUME-ROLE-SATELLITE) | `string` | n/a | yes |
 | hub\_destination\_cidr\_blocks | List of CIDRs to be routed for the hub | `list` | `[]` | no |
+| route\_entire\_satellite\_vpc | Boolean flag for toggling the creation of network routes for all the subnets of the satellite VPC | `bool` | `false` | no |
 | satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
 | satellite\_destination\_cidr\_blocks | List of CIDRs to be routed for the satellite | `list` | `[]` | no |
 | subnet\_filters | List of maps selecting the subnet(s) for which the routing will be added | <pre>list(object({<br>    name   = string<br>    values = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "name": "tag:Name",<br>    "values": [<br>      "private"<br>    ]<br>  }<br>]<br></pre> | no |

--- a/examples/satellite/main.tf
+++ b/examples/satellite/main.tf
@@ -25,4 +25,6 @@ module "tgw-satellite" {
   subnet_filters = var.subnet_filters
 
   transit_gateway_hub_name = var.transit_gateway_hub_name
+
+  route_entire_satellite_vpc = var.route_entire_satellite_vpc
 }

--- a/examples/satellite/variables.auto.tfvars
+++ b/examples/satellite/variables.auto.tfvars
@@ -22,3 +22,5 @@ subnet_filters = [
 ]
 
 transit_gateway_hub_name = "test-tgw-fixture"
+
+route_entire_satellite_vpc = true

--- a/examples/satellite/variables.tf
+++ b/examples/satellite/variables.tf
@@ -71,3 +71,9 @@ variable "transit_gateway_id" {
   type        = string
   default     = ""
 }
+
+variable "route_entire_satellite_vpc" {
+  description = "Boolean flag for toggling the creation of network routes for all the subnets of the satellite VPC"
+  type        = bool
+  default     = false
+}

--- a/locals.tf
+++ b/locals.tf
@@ -6,7 +6,7 @@ locals {
   transit_gateway_route_table_id = var.transit_gateway_route_table_id == "" ? data.aws_ec2_transit_gateway_route_table.this[0].id : var.transit_gateway_route_table_id
 
   routes_in_tables = [
-    for pair in setproduct(data.aws_route_table.this[*].route_table_id, var.satellite_destination_cidr_blocks) : {
+    for pair in setproduct(var.route_entire_satellite_vpc ? data.aws_route_tables.all[0].ids : data.aws_route_table.this[*].route_table_id, var.satellite_destination_cidr_blocks) : {
       table_id        = pair[0]
       dest_cidr_block = pair[1]
     }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,9 @@ variable "transit_gateway_hub_name" {
   type        = string
   default     = ""
 }
+
+variable "route_entire_satellite_vpc" {
+  description = "Boolean flag for toggling the creation of network routes for all the subnets of the satellite VPC"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Adds option to route the entire VPC through the TGW

## Description
AWS only accepts 1 subnet per AZ when the VPC is attached to the TGW.
When the other subnets from those AZs need to be routed through the TGW, this new option should be used.

## Testing Instructions
N/A
## How to roll out
N/A

## Notes
Partially resolves #9 

## Demo
N/A
