### PR TITLE
Allows the hub to also play the role of the satellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Check the `subnet_name_keyword_selector` variable if you want to change this.
 | satellite\_create | Boolean flag for toggling the handling of satellite resources | `bool` | `false` | no |
 | satellite\_destination\_cidr\_blocks | List of CIDRs to be routed for the satellite | `list` | `[]` | no |
 | subnet\_filters | List of maps selecting the subnet(s) for which the routing will be added | <pre>list(object({<br>    name   = string<br>    values = list(string)<br>  }))<br></pre> | <pre>[<br>  {<br>    "name": "tag:Name",<br>    "values": [<br>      "private"<br>    ]<br>  }<br>]<br></pre> | no |
+| transit\_gateway\_default\_route\_table\_association | Set this to false when the hub account also becomes a satellite. Check the official docs for more info. | `bool` | `true` | no |
+| transit\_gateway\_default\_route\_table\_propagation | Set this to false when the hub account also becomes a satellite. Check the official docs for more info. | `bool` | `true` | no |
 | transit\_gateway\_hub\_name | Name of the Transit Gateway to attach to | `string` | `""` | no |
 | transit\_gateway\_id | Identifier of the Transit Gateway | `string` | `""` | no |
 | transit\_gateway\_route\_table\_id | Identifier of the Transit Gateway Route Table | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   transit_gateway_id = local.transit_gateway_id
   vpc_id             = data.aws_vpc.this[0].id
 
+  transit_gateway_default_route_table_association = var.transit_gateway_default_route_table_association
+  transit_gateway_default_route_table_propagation = var.transit_gateway_default_route_table_propagation
+
   # When we create the TGW and the association through RAM in one run, we need
   # this to escape the race condition.
   depends_on = [var.ram_resource_association_id]

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,15 @@ variable "route_entire_satellite_vpc" {
   type        = bool
   default     = false
 }
+
+variable "transit_gateway_default_route_table_association" {
+  description = "Set this to false when the hub account also becomes a satellite. Check the official docs for more info."
+  type        = bool
+  default     = true
+}
+
+variable "transit_gateway_default_route_table_propagation" {
+  description = "Set this to false when the hub account also becomes a satellite. Check the official docs for more info."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Allows the hub to also play the role of the satellite

## Description
Upcoming release tag: `v1.6.0`.
This PR allows the hub AWS account to also play the role of the satellite. It is particularly useful when you have VPCs in the hub account that you want to attach to the TGW.


## Testing Instructions
N/A


## How to roll out
N/A


## Notes
N/A

## Demo
N/A
